### PR TITLE
Expansion of the available aggregate functions and adapt to the Oracle behaviour more closely.

### DIFF
--- a/src/sql_lex.xrl
+++ b/src/sql_lex.xrl
@@ -185,11 +185,30 @@ Erlang code.
     {"^(?i)(ORDERED_SET)$",     'ORDERED_SET'},
 
     % AMMSCs
-    {"^(?i)(AVG)$",             'AMMSC'},
-    {"^(?i)(MIN)$",             'AMMSC'},
-    {"^(?i)(MAX)$",             'AMMSC'},
-    {"^(?i)(SUM)$",             'AMMSC'},
-    {"^(?i)(COUNT)$",           'AMMSC'},
+    {"^(?i)(AVG)$",             'AMMSC3'},
+    {"^(?i)(CORR1)$",           'AMMSC2'},
+    {"^(?i)(COUNT)$",           'AMMSC4'},
+    {"^(?i)(COVAR_POP)$",       'AMMSC2'},
+    {"^(?i)(COVAR_SAMP)$",      'AMMSC2'},
+    {"^(?i)(MAX)$",             'AMMSC3'},
+    {"^(?i)(MEDIAN)$",          'AMMSC1'},
+    {"^(?i)(MIN)$",             'AMMSC3'},
+    {"^(?i)(REGR_AVGX)$",       'AMMSC2'},
+    {"^(?i)(REGR_AVGY)$",       'AMMSC2'},
+    {"^(?i)(REGR_COUNT)$",      'AMMSC2'},
+    {"^(?i)(REGR_INTERCEPT)$",  'AMMSC2'},
+    {"^(?i)(REGR_R2)$",         'AMMSC2'},
+    {"^(?i)(REGR_SLOPE)$",      'AMMSC2'},
+    {"^(?i)(REGR_SXX)$",        'AMMSC2'},
+    {"^(?i)(REGR_SXY)$",        'AMMSC2'},
+    {"^(?i)(REGR_SYY)$",        'AMMSC2'},
+    {"^(?i)(STDDEV)$",          'AMMSC3'},
+    {"^(?i)(STDDEV_POP)$",      'AMMSC1'},
+    {"^(?i)(STDDEV_SAMP)$",     'AMMSC1'},
+    {"^(?i)(SUM)$",             'AMMSC3'},
+    {"^(?i)(VAR_POP)$",         'AMMSC3'},
+    {"^(?i)(VAR_SAMP)$",        'AMMSC1'},
+    {"^(?i)(VARIANCE)$",        'AMMSC3'},
 
     % FUNs
     {"^(?i)(TO_CHAR)$",         'FUNS'},
@@ -216,7 +235,6 @@ Erlang code.
     {"^(?i)(BOOL_AND)$",        'UFUN'},
     {"^(?i)(BOOL_OR)$",         'UFUN'},
     {"^(?i)(SELECTIVITY)$",     'UFUN'},
-    {"^(?i)(STDDEV_POP)$",      'UFUN'},
 
     % Truncate
     {"^(?i)(TRUNCATE)$",        'TRUNCATE'},
@@ -250,7 +268,10 @@ match_any(TokenChars, TokenLen, _TokenLine, []) ->
 match_any(TokenChars, TokenLen, TokenLine, [{P,T}|TPs]) ->
     case re:run(TokenChars, P, [{capture, first, list}]) of
         {match,[_]} ->
-            if (T =:= 'AMMSC') orelse
+            if (T =:= 'AMMSC1') orelse
+               (T =:= 'AMMSC2') orelse
+               (T =:= 'AMMSC3') orelse
+               (T =:= 'AMMSC4') orelse
                (T =:= 'FUNS') orelse
                (T =:= 'UFUN') -> {token, {T, TokenLine, list_to_atom(TokenChars)}};
             true              -> {token, {T, TokenLine}}

--- a/src/sqlparse.yrl
+++ b/src/sqlparse.yrl
@@ -182,7 +182,10 @@ Terminals
  COMPARISON
  ALL
  FUNS
- AMMSC
+ AMMSC1
+ AMMSC2
+ AMMSC3
+ AMMSC4
  ANY
  AS
  ASC
@@ -964,10 +967,15 @@ function_ref -> NAME '.' NAME '(' fun_args ')'                                  
 function_ref -> NAME '(' fun_args ')'                                                           : {'fun', unwrap_bin('$1'), make_list('$3')}.
 function_ref -> FUNS                                                                            : {'fun', unwrap_bin('$1'), []}.
 function_ref -> FUNS  '(' fun_args ')'                                                          : {'fun', unwrap_bin('$1'), make_list('$3')}.
-function_ref -> AMMSC '(' '*' ')'                                                               : {'fun', unwrap_bin('$1'), [<<"*">>]}.
-function_ref -> AMMSC '(' DISTINCT column_ref ')'                                               : {'fun', unwrap_bin('$1'), [{'distinct', '$4'}]}.
-function_ref -> AMMSC '(' ALL scalar_exp ')'                                                    : {'fun', unwrap_bin('$1'), [{'all', '$4'}]}.
-function_ref -> AMMSC '(' scalar_exp ')'                                                        : {'fun', unwrap_bin('$1'), make_list('$3')}.
+function_ref -> AMMSC1 '(' scalar_exp ')'                                                       : {'fun', unwrap_bin('$1'), make_list('$3')}.
+function_ref -> AMMSC2 '(' scalar_exp ',' scalar_exp ')'                                        : {'fun', unwrap_bin('$1'), make_list(lists:flatten(['$3'] ++ ['$5']))}.
+function_ref -> AMMSC3 '(' DISTINCT scalar_exp ')'                                              : {'fun', unwrap_bin('$1'), [{'distinct', '$4'}]}.
+function_ref -> AMMSC3 '(' ALL scalar_exp ')'                                                   : {'fun', unwrap_bin('$1'), [{'all', '$4'}]}.
+function_ref -> AMMSC3 '(' scalar_exp ')'                                                       : {'fun', unwrap_bin('$1'), make_list('$3')}.
+function_ref -> AMMSC4 '(' '*' ')'                                                              : {'fun', unwrap_bin('$1'), [<<"*">>]}.
+function_ref -> AMMSC4 '(' DISTINCT scalar_exp ')'                                              : {'fun', unwrap_bin('$1'), [{'distinct', '$4'}]}.
+function_ref -> AMMSC4 '(' ALL scalar_exp ')'                                                   : {'fun', unwrap_bin('$1'), [{'all', '$4'}]}.
+function_ref -> AMMSC4 '(' scalar_exp ')'                                                       : {'fun', unwrap_bin('$1'), make_list('$3')}.
 
 fun_args -> fun_arg                                                                             : ['$1']. 
 fun_args -> fun_arg ',' fun_args                                                                : ['$1' | '$3'].

--- a/src/sqlparse_fold.erl
+++ b/src/sqlparse_fold.erl
@@ -1816,6 +1816,24 @@ fold(FType, Fun, Ctx, Lvl, {'primary key', ClmList} = ST) ->
     end,
     {" primary key ("++ClmStr++")", NewCtx2};
 
+% 
+% Handling of aggregate function types 3/4
+%
+fold(FType, Fun, Ctx, _Lvl, {all, Column} = ST) ->
+  NewCtx = case FType of
+             top_down -> Fun(ST, Ctx);
+             bottom_up -> Ctx
+           end,
+  {" all " ++ binary_to_list(Column)
+    , NewCtx};
+fold(FType, Fun, Ctx, _Lvl, {distinct, Column} = ST) ->
+  NewCtx = case FType of
+             top_down -> Fun(ST, Ctx);
+             bottom_up -> Ctx
+           end,
+  {" distinct " ++ binary_to_list(Column)
+    , NewCtx};
+
 %
 % UNSUPPORTED
 %

--- a/test/select.tst
+++ b/test/select.tst
@@ -277,3 +277,58 @@ UNION ALL
 "SELECT * FROM name_table_1 WHERE name_column_1 = name_column_2 ORDER BY name_column_4 ASC, name_column_5 DESC".
 "SELECT * FROM name_table_1 WHERE name_column_1 = name_column_2 ORDER BY name_column_4 DESC, name_column_5 ASC".
 
+% aggregate functions ----------------------------------------------------------
+
+"SELECT AVG(name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+% "SELECT AVG(ALL name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+% "SELECT AVG(DISTINCT name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT CORR(name_column_3,name_column_4) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT COUNT(*) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT COUNT(name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+% "SELECT COUNT(ALL name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+% "SELECT COUNT(DISTINCT name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT COVAR_POP(name_column_3,name_column_4) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT COVAR_SAMP(name_column_3,name_column_4) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT MAX(name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+% "SELECT MAX(ALL name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+% "SELECT MAX(DISTINCT name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT MEDIAN(name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT MIN(name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+% "SELECT MIN(ALL name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+% "SELECT MIN(DISTINCT name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT REGR_AVGX(name_column_3,name_column_4) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT REGR_AVGY(name_column_3,name_column_4) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT REGR_COUNT(name_column_3,name_column_4) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT REGR_INTERCEPT(name_column_3,name_column_4) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT REGR_R2(name_column_3,name_column_4) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT REGR_SLOPE(name_column_3,name_column_4) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT REGR_SXX(name_column_3,name_column_4) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT REGR_SXY(name_column_3,name_column_4) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT REGR_SYY(name_column_3,name_column_4) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT STDDEV(name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+% "SELECT STDDEV(ALL name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+% "SELECT STDDEV(DISTINCT name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT STDDEV_POP(name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT STDDEV_SAMP(name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT SUM(name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+% "SELECT SUM(ALL name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+% "SELECT SUM(DISTINCT name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT VAR_POP(name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT VAR_SAMPLE(name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT VARIANCE(name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+% "SELECT VARIANCE(ALL name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+% "SELECT VARIANCE(DISTINCT name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+
+"SELECT * FROM name_table_1 WHERE name_column_1 = name_column_2 AND COUNT(name_column_3)".
+
+"SELECT column_1,column_2,COUNT(column_3) 
+   FROM name_table_1 
+  WHERE name_column_1 = name_column_2 
+  GROUP BY column_1,column_2,REGR_COUNT(name_column_3,name_column_4)".
+
+"SELECT column_1,column_2,COUNT(column_3) 
+   FROM name_table_1 
+  WHERE name_column_1 = name_column_2 
+  GROUP BY column_1,column_2,column_3 
+ HAVING COUNT(name_column_3) > 5".
+

--- a/test/select.tst
+++ b/test/select.tst
@@ -280,22 +280,22 @@ UNION ALL
 % aggregate functions ----------------------------------------------------------
 
 "SELECT AVG(name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
-% "SELECT AVG(ALL name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
-% "SELECT AVG(DISTINCT name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT AVG(ALL name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT AVG(DISTINCT name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
 "SELECT CORR(name_column_3,name_column_4) FROM name_table_1 WHERE name_column_1 = name_column_2".
 "SELECT COUNT(*) FROM name_table_1 WHERE name_column_1 = name_column_2".
 "SELECT COUNT(name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
-% "SELECT COUNT(ALL name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
-% "SELECT COUNT(DISTINCT name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT COUNT(ALL name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT COUNT(DISTINCT name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
 "SELECT COVAR_POP(name_column_3,name_column_4) FROM name_table_1 WHERE name_column_1 = name_column_2".
 "SELECT COVAR_SAMP(name_column_3,name_column_4) FROM name_table_1 WHERE name_column_1 = name_column_2".
 "SELECT MAX(name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
-% "SELECT MAX(ALL name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
-% "SELECT MAX(DISTINCT name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT MAX(ALL name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT MAX(DISTINCT name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
 "SELECT MEDIAN(name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
 "SELECT MIN(name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
-% "SELECT MIN(ALL name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
-% "SELECT MIN(DISTINCT name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT MIN(ALL name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT MIN(DISTINCT name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
 "SELECT REGR_AVGX(name_column_3,name_column_4) FROM name_table_1 WHERE name_column_1 = name_column_2".
 "SELECT REGR_AVGY(name_column_3,name_column_4) FROM name_table_1 WHERE name_column_1 = name_column_2".
 "SELECT REGR_COUNT(name_column_3,name_column_4) FROM name_table_1 WHERE name_column_1 = name_column_2".
@@ -306,18 +306,18 @@ UNION ALL
 "SELECT REGR_SXY(name_column_3,name_column_4) FROM name_table_1 WHERE name_column_1 = name_column_2".
 "SELECT REGR_SYY(name_column_3,name_column_4) FROM name_table_1 WHERE name_column_1 = name_column_2".
 "SELECT STDDEV(name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
-% "SELECT STDDEV(ALL name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
-% "SELECT STDDEV(DISTINCT name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT STDDEV(ALL name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT STDDEV(DISTINCT name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
 "SELECT STDDEV_POP(name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
 "SELECT STDDEV_SAMP(name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
 "SELECT SUM(name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
-% "SELECT SUM(ALL name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
-% "SELECT SUM(DISTINCT name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT SUM(ALL name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT SUM(DISTINCT name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
 "SELECT VAR_POP(name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
 "SELECT VAR_SAMPLE(name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
 "SELECT VARIANCE(name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
-% "SELECT VARIANCE(ALL name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
-% "SELECT VARIANCE(DISTINCT name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT VARIANCE(ALL name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
+"SELECT VARIANCE(DISTINCT name_column_3) FROM name_table_1 WHERE name_column_1 = name_column_2".
 
 "SELECT * FROM name_table_1 WHERE name_column_1 = name_column_2 AND COUNT(name_column_3)".
 
@@ -332,3 +332,7 @@ UNION ALL
   GROUP BY column_1,column_2,column_3 
  HAVING COUNT(name_column_3) > 5".
 
+"SELECT column_1,column_2,COUNT(column_3) 
+   FROM name_table_1 
+  WHERE name_column_1 = name_column_2 
+  ORDER BY column_1,column_2,REGR_COUNT(name_column_3,name_column_4)".


### PR DESCRIPTION
The changes are based on the Oracle documentation ([Database SQL Language Reference](https://docs.oracle.com/cd/E11882_01/server.112/e41084/functions003.htm#SQLRF20035)) .

Supported aggregate functions are:

Type 1: `AMMSC1(expr)`:

-  `MEDIAN`
-  `STDDEV_POP`
- `STDDEV_SAMP`
- `VAR_SAMP `

Type 2: `AMMSC2(expr,expr2)`:

-  `CORR`
-  `COVAR_POP`
- `COVAR_SAMP`
- `REGR_AVGX `
- `REGR_AVGY `
- `REGR_COUNT `
- `REGR_INTERCEPT `
- `REGR_R2 `
- `REGR_SLOPE `
- `REGR_SXX `
- `REGR_SXY `
- `REGR_SYY `

Type 3: `AMMSC3(expr)` / `AMMSC3(ALL expr)` / `AMMSC3(DISTINCT expr)`:

-  `AVG`
-  `MAX`
- `MIN`
- `STDDEV`
- `SUM`
- `VAR_POP`
- `VARIANCE`

Type 3: `AMMSC4(*)` / `AMMSC4(expr)` / `AMMSC3(ALL expr)` / `AMMSC3(DISTINCT expr)`:

-  `COUNT`

This pull request contains pull request #47 and resolves issue #46.

