### PR TITLE
COMPARISON regex - from higher to lower specificity

### DIFF
--- a/src/sql_lex.xrl
+++ b/src/sql_lex.xrl
@@ -30,7 +30,7 @@ Rules.
 ((\/\*)[^\*\/]*(\*\/))                              : {token, {'HINT', TokenLine, TokenChars}}.
 
 % punctuation
-(!=|\^=|<>|<|>|<=|>=)                               : {token, {'COMPARISON', TokenLine, list_to_atom(TokenChars)}}.
+(!=|\^=|<>|<=|>=|<|>)                               : {token, {'COMPARISON', TokenLine, list_to_atom(TokenChars)}}.
 ([=\|\-\+\*\/\(\)\,\.\;]|(\|\|)|(:=)|(=>)|(div))    : {token, {list_to_atom(TokenChars), TokenLine}}.
 
 % JSON


### PR DESCRIPTION
Hi I noticed the regex wasn't matching when I tried it out in a regex tester, then I noticed it would match a string of `>` but fail to match `>=`. Looked at the pattern and realised the `>` was matching first. Leex regex implementation may work some other way but I'm giving the PR anyway, just in case.